### PR TITLE
Protect djtc.me from email spoofing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,10 +82,6 @@ repos:
     rev: v2.12.0
     hooks:
       - id: hadolint
-  - repo: "https://github.com/crate-ci/typos"
-    rev: v1.26.0
-    hooks:
-      - id: typos
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.20.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # DNS
 
 This repo contains the DNS configuration for my various domains using OctoDNS.
+
+For domains that don't send email, I follow the [advice from gov.uk](https://www.gov.uk/guidance/protect-domains-that-dont-send-email).

--- a/dns/zones/djtc.me.yaml
+++ b/dns/zones/djtc.me.yaml
@@ -1,12 +1,51 @@
 ---
-# Alias root to domchester.com
 "":
+  # Alias root to domchester.com
+  - octodns:
+      cloudflare:
+        auto-ttl: true
+    ttl: 300
+    type: ALIAS
+    value: domchester.com.
+
+  - octodns:
+      cloudflare:
+        auto-ttl: true
+    ttl: 300
+    type: TXT
+    value: v=spf1 -all
+
+  - octodns:
+      cloudflare:
+        auto-ttl: true
+    ttl: 300
+    type: MX
+    values:
+      - exchange: .
+        preference: 0
+
+"*._domainkey":
   octodns:
     cloudflare:
       auto-ttl: true
   ttl: 300
-  type: ALIAS
-  value: domchester.com.
+  type: TXT
+  value: v=DKIM1\; p=
+
+_dmarc:
+  octodns:
+    cloudflare:
+      auto-ttl: true
+  ttl: 300
+  type: TXT
+  value: >-
+    v=DMARC1\;
+    p=reject\;
+    sp=reject\;
+    adkim=s\;
+    aspf=s\;
+    fo=1\;
+    rua=mailto:09930ca91112409dad432bb7dab3dc29@dmarc-reports.cloudflare.net
 
 www:
   octodns:


### PR DESCRIPTION
Follows gov.uk advice - https://www.gov.uk/guidance/protect-domains-that-dont-send-email